### PR TITLE
fix(css): use better primary color for light mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,7 +7,7 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #C6D99C;
+  --ifm-color-primary: #76a01b;
   --ifm-color-secondary: #000000;
 
   --ifm-color-success: #00ff8c;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27026029/175997099-2090a803-4ab0-4486-a0c2-510308d79491.png)

Unfortunately our new light mode color scheme is not compatible with the way docusaurus v2 styling works. I changed the color a little bit ;)