### PR TITLE
fix(css): improve search highlight color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -31,6 +31,11 @@ html[data-theme='dark'] {
   --search-local-highlight-color: #4d4d4d;
 }
 
+html[data-theme='dark'] .hitWrapper_sAK8 mark {
+  background: none;
+  color: #ccc;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.1);
   display: block;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,6 +27,8 @@ html[data-theme='dark'] {
   --ifm-footer-background-color: #333333;
   --ifm-code-background: #333333;
   --ifm-navbar-search-input-background-color: #666666;
+  
+  --search-local-highlight-color: #4d4d4d;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
The contrast of search highlights within dark mode was too high. 
**Before:**
<img width="690" alt="CleanShot 2022-06-30 at 12 50 38@2x" src="https://user-images.githubusercontent.com/14016944/176659820-c2d81082-770f-4a81-b36e-d802f70e3e64.png">

**Result:** 
<img width="741" alt="CleanShot 2022-06-30 at 12 49 46@2x" src="https://user-images.githubusercontent.com/14016944/176659555-6ed535a4-0fde-4ed3-9bd9-0f25f5c191c9.png">
